### PR TITLE
Create release builds with Github Actions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,54 @@
+name: Create Release Builds
+
+on:
+  push:
+    tags:
+      - "v*" # matches v1.0.1, v1.2, v2, etc
+
+jobs:
+  once:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create a release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+
+  build:
+    name: Create cross-platform release build, tag and upload binaries
+    needs: once
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build release version
+      run: |
+        mkdir bin
+        cd bin
+        ../configure.py
+        make minion -j2
+    - name: Make Zip
+      run: 
+        7z a -tzip ${{ github.workspace }}/bin/minion-${{ matrix.os }}.zip ${{ github.workspace }}/bin/minion
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.once.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/bin/minion-${{ matrix.os }}.zip
+        asset_name: minion-${{ matrix.os }}.zip
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This adds the functionality to create a release draft with compiled assets for linux and macos.

It gets triggered for commits with a tag "v*". Feel free to change the regex to your liking in the yaml.

An example run can be seen in here:

![firefox_ZcBrn2pTOf](https://user-images.githubusercontent.com/4727301/115924508-b9c9b680-a477-11eb-8bd8-40bd41d06fe6.png)

It takes around 15 minutes with -j2 on 2 core github vms.

![firefox_EXflEL4XET](https://user-images.githubusercontent.com/4727301/115925281-cbf82480-a478-11eb-9709-006e7f8f9ed5.png)


A Windows release can be added by adding "windows-latest" to os.matrix. But I suspect it won't work directly without making changes on the make procedure.