### PR TITLE
fix compile errors; use standard C++ limit

### DIFF
--- a/minion/MILtools/sym_output.h
+++ b/minion/MILtools/sym_output.h
@@ -21,8 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <set>
-
-#include <limits.h> /* INT_MIN, INT_MAX */
+#include <limits>
 
 std::vector<std::vector<DomainInt>> build_graph(std::vector<std::set<SysInt>> graph,
                                                 const std::vector<std::set<SysInt>>& partition);
@@ -682,8 +681,8 @@ struct InstanceStats {
     case CT_GACALLDIFF: {
       (*alldiff)++;
       SysInt num = 0;
-      DomainInt upper = INT_MIN;
-      DomainInt lower = INT_MAX;
+      DomainInt upper = std::numeric_limits<int>::min();
+      DomainInt lower = std::numeric_limits<int>::max();
       for(SysInt j = 0; j < (SysInt)i.vars.size(); j++) {
         for(SysInt k = 0; k < (SysInt)i.vars[j].size(); k++) {
           num++;

--- a/minion/constraints/constraint_nvalue.h
+++ b/minion/constraints/constraint_nvalue.h
@@ -27,6 +27,7 @@
 
 #include "constraint_checkassign.h"
 #include <math.h>
+#include <limits>
 
 template <typename VarArray, typename VarResult>
 struct LessEqualNvalueConstraint : public AbstractConstraint {
@@ -168,8 +169,8 @@ struct GreaterEqualNvalueConstraint : public AbstractConstraint {
 
   void propagateImpl() {
     std::set<DomainInt> assigned;
-    DomainInt min_unassigned = INT_MAX;
-    DomainInt max_unassigned = INT_MIN;
+    DomainInt min_unassigned = std::numeric_limits<int>::max();
+    DomainInt max_unassigned = std::numeric_limits<int>::min();
     DomainInt unassignedCount = 0;
     for(unsigned i = 0; i < vars.size(); ++i) {
       if(vars[i].isAssigned()) {

--- a/minion/system/minlib/basic_sys.hpp
+++ b/minion/system/minlib/basic_sys.hpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include <assert.h>
-#include <limits.h>
+#include <limits>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This fixes compile failing under Linux gcc

c++ standard uses <limits> rather than <limits.h>, and the new std::numeric_limits<int>::min and max