### PR TITLE
Add build_constraints to libminion.a

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -450,4 +450,4 @@ with open(outname, "w") as out:
         if arg.buildsystem == "make":
             out.write('libminion.a: $(CONOBJS) $(MINLIBOBJS)\n')
         out.write('\t' + 'ar rcs libminion.a' +
-                varsub('MINLIBOBJS') + '\n')
+                varsub('MINLIBOBJS') + varsub('CONOBJS') + '\n')


### PR DESCRIPTION
#6 @ChrisJefferson 

This PR also adds the build_constraint objects from `build/src` into `libminion.a`.

This solves the following linking issue:

<img width="1321" alt="Screenshot 2023-09-28 at 17 46 26" src="https://github.com/minion/minion/assets/44070547/73526be1-e700-422b-a151-83380191627e">
