### PR TITLE
FFI functions for Rust bindings

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -200,16 +200,103 @@ void finaliseModel(CSPInstance& instance) {
 /*                    REXPORTING INLINE FUNCTIONS                    */
 /*********************************************************************/
 
-SearchOptions newSearchOptions() {
-  return SearchOptions();
+SearchOptions* newSearchOptions() {
+  return new SearchOptions();
 }
 
-SearchMethod newSearchMethod() {
-  return SearchMethod();
+SearchMethod* newSearchMethod() {
+  return new SearchMethod();
 }
 
 CSPInstance* newInstance() {
   return new CSPInstance();
+}
+
+ConstraintBlob* newConstraintBlob(ConstraintType constraint_type) {
+  return new ConstraintBlob(lib_getConstraint(constraint_type));
+}
+
+SearchOrder* newSearchOrder(std::vector<Var>& vars,VarOrderEnum orderEnum, bool findOneSol) {
+  return new SearchOrder(vars,orderEnum,findOneSol);
+}
+
+void searchOptions_free(SearchOptions* searchOptions) {
+  delete searchOptions;
+}
+
+void searchMethod_free(SearchMethod* searchMethod) {
+  delete searchMethod;
+}
+
+void instance_free(CSPInstance* instance) {
+  delete instance;
+}
+
+void constraint_free(ConstraintBlob* constraint) {
+  delete constraint;
+}
+
+void searchOrder_free(SearchOrder* searchOrder) {
+  delete searchOrder;
+}
+
+Var getVarByName(CSPInstance& instance, char* name) {
+
+  return instance.vars.getSymbol(string(name));
+}
+
+void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2) {
+  newVar(instance, string(name), type, std::vector<DomainInt>({bound1,bound2}));
+}
+
+
+void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder) {
+  instance.searchOrder.push_back(searchOrder);
+}
+
+void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint) {
+  instance.constraints.push_back(constraint);
+}
+
+void printMatrix_addVar(CSPInstance& instance, Var var) {
+  instance.print_matrix.push_back({var});
+}
+
+int printMatrix_getValue(int idx) {
+  // FIXME: does not work with minion debug mode
+  return globals->state_m->getPrintMatrix()[idx][0].assignedValue();
+}
+
+void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars) {
+  constraint.vars.push_back(vars);
+}
+
+void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants) {
+  constraint.constants.push_back(constants);
+}
+
+std::vector<Var>* vec_var_new() {
+  return new std::vector<Var>();
+}
+
+void vec_var_push_back(std::vector<Var>* vec, Var var) {
+  vec->push_back(var);
+}
+
+void vec_var_free(std::vector<Var>* vec) {
+  delete vec;
+}
+
+std::vector<DomainInt>* vec_int_new() {
+  return new std::vector<DomainInt>();
+}
+void vec_int_push_back(std::vector<DomainInt>* vec, int n) {
+  vec->push_back(n);
+}
+
+
+void vec_int_free(std::vector<DomainInt>* vec) {
+  delete vec;
 }
 
 #endif

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "libwrapper.h"
+#include "inputfile_parse/CSPSpec.h"
 #include "minion.h"
 #include "command_search.h"
 #include "info_dumps.h"
@@ -205,6 +206,10 @@ SearchOptions newSearchOptions() {
 
 SearchMethod newSearchMethod() {
   return SearchMethod();
+}
+
+CSPInstance* newInstance() {
+  return new CSPInstance();
 }
 
 #endif

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -264,8 +264,7 @@ void printMatrix_addVar(CSPInstance& instance, Var var) {
 }
 
 int printMatrix_getValue(int idx) {
-  // FIXME: does not work with minion debug mode
-  return globals->state_m->getPrintMatrix()[idx][0].assignedValue();
+  return checked_cast<int>(globals->state_m->getPrintMatrix()[idx][0].assignedValue());
 }
 
 void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars) {

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -9,6 +9,7 @@
 #include "minion.h"
 #include "command_search.h"
 #include "info_dumps.h"
+#include "solver.h"
 #include "system/minlib/exceptions.hpp"
 #include <iomanip>
 
@@ -193,6 +194,18 @@ void finaliseModel(CSPInstance& instance) {
 
 }
 
+
+/*********************************************************************/
+/*                    REXPORTING INLINE FUNCTIONS                    */
+/*********************************************************************/
+
+SearchOptions newSearchOptions() {
+  return SearchOptions();
+}
+
+SearchMethod newSearchMethod() {
+  return SearchMethod();
+}
 
 #endif
 

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -28,8 +28,9 @@ void resetMinion() {
   globals = new Globals();
 }
 
+std::mutex global_minion_lock;
 ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance, bool(*callback)(void)) {
-
+  std::lock_guard<std::mutex> guard(global_minion_lock);
   ReturnCodes returnCode = ReturnCodes::OK;
 
   /*

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -215,6 +215,8 @@ SearchOptions newSearchOptions();
 
 SearchMethod newSearchMethod();
 
+CSPInstance* newInstance();
+
 
 #endif
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 
+#include "ConstraintEnum.h"
+#include "inputfile_parse/CSPSpec.h"
 #include "minion.h"
 #include "solver.h"
 /*
@@ -122,6 +124,7 @@
  *
  */
 #include "minion.h"
+#include <vector>
 void resetMinion();
 
 enum ReturnCodes {
@@ -186,10 +189,10 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
 Var constantAsVar(DomainInt n);
 
 
-/*********************************************************************/
-/*                    REXPORTING INLINE FUNCTIONS                    */
-/*********************************************************************/
 
+/*******************************************************/
+/*                    FFI FUNCTIONS                    */
+/*******************************************************/
 /*
  * ConstraintDef* lib_getConstraint:
  *  
@@ -209,14 +212,40 @@ Var constantAsVar(DomainInt n);
  */
 ConstraintDef* lib_getConstraint(ConstraintType t);
 
-//These are inlined constructors, so rust cannot see them
-
-SearchOptions newSearchOptions();
-
-SearchMethod newSearchMethod();
-
+SearchOptions* newSearchOptions();
+SearchMethod* newSearchMethod();
 CSPInstance* newInstance();
+ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
+SearchOrder* newSearchOrder(std::vector<Var>& vars,VarOrderEnum orderEnum, bool findOneSol);
 
+void searchOptions_free(SearchOptions* searchOptions);
+void searchMethod_free(SearchMethod* searchMethod);
+void instance_free(CSPInstance* instance);
+void constraint_free(ConstraintBlob* constraint);
+void searchOrder_free(SearchOrder* searchOrder);
+
+Var getVarByName(CSPInstance& instance, char* name);
+void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2);
+
+void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder);
+void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
+
+// Both these assume print matrix of form [[x],[y],[z]]
+void printMatrix_addVar(CSPInstance& instance, Var var);
+
+// Should be called only when minion has results in a callback
+int printMatrix_getValue(int idx);
+
+void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars);
+void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants);
+
+std::vector<Var>* vec_var_new();
+void vec_var_push_back(std::vector<Var>* vec, Var var);
+void vec_var_free(std::vector<Var>* vec);
+
+std::vector<DomainInt>* vec_int_new();
+void vec_int_push_back(std::vector<DomainInt>* vec, int n);
+void vec_int_free(std::vector<DomainInt>* vec);
 
 #endif
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -1,19 +1,19 @@
 // Minion https://github.com/minion/minion
 // SPDX-License-Identifier: MPL-2.0
 
-
 #include "ConstraintEnum.h"
 #include "inputfile_parse/CSPSpec.h"
 #include "minion.h"
 #include "solver.h"
+
 /*
  * Functions for using minion as a library.
  *
  * Primarily for use by the Rust bindings - the library abstractions provided
  * here are neither complete nor safe.
  *
- * The Rust bindings (github.com/conjure-cp/conjure-oxide) should provide a safe
- * but low-level way to use Minion as a library.
+ * The Rust bindings (https://github.com/conjure-cp/conjure-oxide/tree/main/solvers/minion) 
+ * should provide a safe but low-level way to use Minion as a library.
  */
 
 /* MODEL BUILDING - AN EXAMPLE
@@ -193,6 +193,22 @@ Var constantAsVar(DomainInt n);
 /*******************************************************/
 /*                    FFI FUNCTIONS                    */
 /*******************************************************/
+
+/*
+ * The below functions are primarily for use by FFI wrappers of Minion.
+ *
+ * This means that:
+ *   - Complex structures that other languages do not understand are returned as
+ *     opaque pointers.
+ *
+ *   - Use of char* instead of string.
+ *
+ *   - Various inline functions are re-exported so they can be seen.
+ *
+ *   - Manual constructors and deconstructors are provided for languages that
+ *     do not use them.
+ */
+
 /*
  * ConstraintDef* lib_getConstraint:
  *  
@@ -212,33 +228,41 @@ Var constantAsVar(DomainInt n);
  */
 ConstraintDef* lib_getConstraint(ConstraintType t);
 
+/***** Constructors *****/
 SearchOptions* newSearchOptions();
 SearchMethod* newSearchMethod();
 CSPInstance* newInstance();
 ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
 SearchOrder* newSearchOrder(std::vector<Var>& vars,VarOrderEnum orderEnum, bool findOneSol);
 
+/***** Destructors *****/
 void searchOptions_free(SearchOptions* searchOptions);
 void searchMethod_free(SearchMethod* searchMethod);
 void instance_free(CSPInstance* instance);
 void constraint_free(ConstraintBlob* constraint);
 void searchOrder_free(SearchOrder* searchOrder);
 
+/***** Variable Helper Functions *****/
 Var getVarByName(CSPInstance& instance, char* name);
 void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2);
 
+/***** Class member functions *****/
 void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder);
 void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
 
-// Both these assume print matrix of form [[x],[y],[z]]
+/*
+ * printMatrix_* functions assume the print matrix is of the form
+ * [[x],[y],[z],...].
+ */
 void printMatrix_addVar(CSPInstance& instance, Var var);
 
-// Should be called only when minion has results in a callback
+// Should be called only when minion has results in a callback.
 int printMatrix_getValue(int idx);
 
 void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars);
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants);
 
+/***** std::vector Wrappers *****/
 std::vector<Var>* vec_var_new();
 void vec_var_push_back(std::vector<Var>* vec, Var var);
 void vec_var_free(std::vector<Var>* vec);

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -1,6 +1,8 @@
 // Minion https://github.com/minion/minion
 // SPDX-License-Identifier: MPL-2.0
 
+
+#include "minion.h"
 /*
  * Functions for using minion as a library.
  *

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -3,6 +3,7 @@
 
 
 #include "minion.h"
+#include "solver.h"
 /*
  * Functions for using minion as a library.
  *
@@ -184,6 +185,11 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
  */
 Var constantAsVar(DomainInt n);
 
+
+/*********************************************************************/
+/*                    REXPORTING INLINE FUNCTIONS                    */
+/*********************************************************************/
+
 /*
  * ConstraintDef* lib_getConstraint:
  *  
@@ -202,6 +208,12 @@ Var constantAsVar(DomainInt n);
  *    ```
  */
 ConstraintDef* lib_getConstraint(ConstraintType t);
+
+//These are inlined constructors, so rust cannot see them
+
+SearchOptions newSearchOptions();
+
+SearchMethod newSearchMethod();
 
 
 #endif


### PR DESCRIPTION
@ChrisJefferson 
The corresponding C++ for https://github.com/conjure-cp/conjure-oxide/pull/28.

Mainly wraps things as FFI safe functions - i.e. using pointers for complex types, re-exporting inline functions, manual constructors and destructors, ....

