### PR TITLE
Add more constraint argument types to libwrapper.h

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,7 +49,6 @@ Standard:        Cpp11
 IndentWidth:     2
 TabWidth:        8
 UseTab:          Never
-BreakBeforeBraces: Attach
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpacesInAngles:  false

--- a/minion/inputfile_parse/CSPSpec.h
+++ b/minion/inputfile_parse/CSPSpec.h
@@ -106,8 +106,10 @@ struct CSPInstance;
 struct ConstraintBlob {
   /// The type of constraint.
   ConstraintDef* constraint;
+
   /// The variables of the problem.
   vector<vector<Var>> vars;
+
   /// Pointer to list of tuples. Only used in Table Constraints.
   std::shared_ptr<TupleList> tuples;
 

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -275,6 +275,10 @@ void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainIn
   constraint.constants.push_back(constants);
 }
 
+void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint) {
+  constraint.internal_constraints.push_back(internal_constraint);
+}
+
 std::vector<Var>* vec_var_new() {
   return new std::vector<Var>();
 }

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -24,14 +24,16 @@ void finaliseModel(CSPInstance& instance);
 
 extern Globals* globals;
 
-void resetMinion() {
+void resetMinion()
+{
   delete globals;
   globals = new Globals();
 }
 
 std::mutex global_minion_lock;
 ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance,
-                      bool (*callback)(void)) {
+                      bool (*callback)(void))
+{
   std::lock_guard<std::mutex> guard(global_minion_lock);
   ReturnCodes returnCode = ReturnCodes::OK;
 
@@ -113,7 +115,9 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
   catch(parse_exception e) {
     cout << "Invalid instance: " << e.what() << endl;
     returnCode = ReturnCodes::INVALID_INSTANCE;
-  } catch(...) { returnCode = ReturnCodes::UNKNOWN_ERROR; }
+  } catch(...) {
+    returnCode = ReturnCodes::UNKNOWN_ERROR;
+  }
 
   // Restore old cout
   cout.rdbuf(oldCoutStreamBuf);
@@ -125,18 +129,21 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
 /*                    Instance building functions                    */
 /*********************************************************************/
 
-void newVar(CSPInstance& instance, string name, VariableType type, vector<DomainInt> bounds) {
+void newVar(CSPInstance& instance, string name, VariableType type, vector<DomainInt> bounds)
+{
   Var v = instance.vars.getNewVar(type, bounds);
   instance.vars.addSymbol(name, v);
   instance.allVars_list.push_back(makeVec(v));
 }
 
-Var constantAsVar(DomainInt constant) {
+Var constantAsVar(DomainInt constant)
+{
   return Var(VAR_CONSTANT, constant);
 }
 
 // Export of inline function get_constraint as bindings dont like inlines!
-ConstraintDef* lib_getConstraint(ConstraintType t) {
+ConstraintDef* lib_getConstraint(ConstraintType t)
+{
   return get_constraint(t);
 }
 
@@ -144,7 +151,8 @@ ConstraintDef* lib_getConstraint(ConstraintType t) {
 /*                    Internal Functions                    */
 /************************************************************/
 
-void finaliseModel(CSPInstance& instance) {
+void finaliseModel(CSPInstance& instance)
+{
   /* Add final touches to model and fill in missing defaults.
    *
    * largely copied from MinionThreeInputReader::finalise, but without
@@ -195,195 +203,237 @@ void finaliseModel(CSPInstance& instance) {
 
 /***** Variable *****/
 
-Var getVarByName(CSPInstance& instance, char* name) {
+Var getVarByName(CSPInstance& instance, char* name)
+{
 
   return instance.vars.getSymbol(string(name));
 }
 
-void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2) {
+void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2)
+{
   newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
 }
 
 /***** Tuple *****/
-TupleList* tupleList_new(vector<vector<DomainInt>>& tupleList) {
+TupleList* tupleList_new(vector<vector<DomainInt>>& tupleList)
+{
   return new TupleList(tupleList);
 }
 
-void tupleList_free(TupleList* tupleList) {
+void tupleList_free(TupleList* tupleList)
+{
   delete tupleList;
 }
 
 /***** Instance *****/
 
-CSPInstance* newInstance() {
+CSPInstance* instance_new()
+{
   return new CSPInstance();
 }
 
-void instance_free(CSPInstance* instance) {
+void instance_free(CSPInstance* instance)
+{
   delete instance;
 }
 
-void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder) {
+void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder)
+{
   instance.searchOrder.push_back(searchOrder);
 }
 
-void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint) {
+void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint)
+{
   instance.constraints.push_back(constraint);
 }
 
-void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist) {
+void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist)
+{
   instance.addTableSymbol(name, std::shared_ptr<TupleList>(tuplelist));
 }
 
-TupleList* instance_getTupleTableSymbol(CSPInstance& instance, char* name) {
+TupleList* instance_getTupleTableSymbol(CSPInstance& instance, char* name)
+{
   return instance.getTableSymbol(name).get();
 }
 
 void instance_addShortTupleTableSymbol(CSPInstance& instance, char* name,
-                                       ShortTupleList* shorttuplelist) {
+                                       ShortTupleList* shorttuplelist)
+{
   instance.addShortTableSymbol(name, std::shared_ptr<ShortTupleList>(shorttuplelist));
 }
 
-ShortTupleList* instance_getShortTupleTableSymbol(CSPInstance& instance, char* name) {
+ShortTupleList* instance_getShortTupleTableSymbol(CSPInstance& instance, char* name)
+{
   return instance.getShortTableSymbol(name).get();
 }
 
-void printMatrix_addVar(CSPInstance& instance, Var var) {
+void printMatrix_addVar(CSPInstance& instance, Var var)
+{
   instance.print_matrix.push_back({var});
 }
 
-int printMatrix_getValue(int idx) {
+int printMatrix_getValue(int idx)
+{
   return checked_cast<int>(globals->state_m->getPrintMatrix()[idx][0].assignedValue());
 }
 
 /***** SearchOptions *****/
 
-SearchOptions* newSearchOptions() {
+SearchOptions* searchOptions_new()
+{
   return new SearchOptions();
 }
 
-void searchOptions_free(SearchOptions* searchOptions) {
+void searchOptions_free(SearchOptions* searchOptions)
+{
   delete searchOptions;
 }
 
 /***** SearchMethod *****/
 
-SearchMethod* newSearchMethod() {
+SearchMethod* searchMethod_new()
+{
   return new SearchMethod();
 }
 
-void searchMethod_free(SearchMethod* searchMethod) {
+void searchMethod_free(SearchMethod* searchMethod)
+{
   delete searchMethod;
 }
 
 /***** SearchOrder *****/
 
-SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol) {
+SearchOrder* searchOrder_new(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol)
+{
   return new SearchOrder(vars, orderEnum, findOneSol);
 }
 
-void searchOrder_free(SearchOrder* searchOrder) {
+void searchOrder_free(SearchOrder* searchOrder)
+{
   delete searchOrder;
 }
 
 /***** ConstraintBlob *****/
 
-ConstraintBlob* newConstraintBlob(ConstraintType constraint_type) {
+ConstraintBlob* constraint_new(ConstraintType constraint_type)
+{
   return new ConstraintBlob(lib_getConstraint(constraint_type));
 }
 
-void constraint_free(ConstraintBlob* constraint) {
+void constraint_free(ConstraintBlob* constraint)
+{
   delete constraint;
 }
 
 // mirrors MinionThreeInputReader::readGeneralConstraint, but over FFI.
 // look there for the why/how
 
-void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars) {
+void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars)
+{
   constraint.vars.push_back(vars);
 }
 
-void constraint_addVar(ConstraintBlob& constraint, Var& var) {
+void constraint_addVar(ConstraintBlob& constraint, Var& var)
+{
   constraint.vars.push_back(makeVec(var));
 }
 
-void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2) {
+void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2)
+{
   vector<Var> vars(2);
   vars[0] = std::move(var1);
   vars[1] = std::move(var2);
   constraint.vars.push_back(std::move(vars));
 }
 
-void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant) {
+void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant)
+{
   constraint.constants.push_back(makeVec(constant));
 }
 
-void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants) {
+void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants)
+{
   constraint.constants.push_back(constants);
 }
 
-void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint) {
+void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint)
+{
   constraint.internal_constraints.push_back(internal_constraint);
 }
 
 void constraint_addConstraintList(ConstraintBlob& constraint,
-                                  vector<ConstraintBlob>& internal_constraints) {
+                                  vector<ConstraintBlob>& internal_constraints)
+{
   constraint.internal_constraints = std::move(internal_constraints);
 }
 
-void constraint_setTuples(ConstraintBlob* constraint, TupleList* tupleList) {
+void constraint_setTuples(ConstraintBlob* constraint, TupleList* tupleList)
+{
   constraint->tuples = std::shared_ptr<TupleList>(tupleList);
 }
 
 /***** Vector Rexports *****/
 
-std::vector<Var>* vec_var_new() {
+std::vector<Var>* vec_var_new()
+{
   return new std::vector<Var>();
 }
 
-void vec_var_push_back(std::vector<Var>* vec, Var var) {
+void vec_var_push_back(std::vector<Var>* vec, Var var)
+{
   vec->push_back(var);
 }
 
-void vec_var_free(std::vector<Var>* vec) {
+void vec_var_free(std::vector<Var>* vec)
+{
   delete vec;
 }
 
-std::vector<DomainInt>* vec_int_new() {
+std::vector<DomainInt>* vec_int_new()
+{
   return new std::vector<DomainInt>();
 }
 
-void vec_int_push_back(std::vector<DomainInt>* vec, int n) {
+void vec_int_push_back(std::vector<DomainInt>* vec, int n)
+{
   vec->push_back(n);
 }
 
-void vec_int_free(std::vector<DomainInt>* vec) {
+void vec_int_free(std::vector<DomainInt>* vec)
+{
   delete vec;
 }
 
-std::vector<ConstraintBlob>* vec_constraints_new() {
+std::vector<ConstraintBlob>* vec_constraints_new()
+{
   return new std::vector<ConstraintBlob>();
 }
 
-void vec_constraints_push_back(std::vector<ConstraintBlob>* vec, ConstraintBlob& constraint) {
+void vec_constraints_push_back(std::vector<ConstraintBlob>* vec, ConstraintBlob& constraint)
+{
   // TODO: how to memory manage this?
   // move?
   vec->push_back(std::move(constraint));
 }
 
-void vec_constraints_free(std::vector<ConstraintBlob>* vec) {
+void vec_constraints_free(std::vector<ConstraintBlob>* vec)
+{
   delete vec;
 }
 
-std::vector<std::vector<DomainInt>>* vec_vec_int_new() {
+std::vector<std::vector<DomainInt>>* vec_vec_int_new()
+{
   return new std::vector<std::vector<DomainInt>>();
 }
 void vec_vec_int_push_back(std::vector<std::vector<DomainInt>>* vec,
-                           std::vector<DomainInt> new_elem) {
+                           std::vector<DomainInt> new_elem)
+{
   vec->push_back(new_elem);
 }
 
-void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec) {
+void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec)
+{
   delete vec;
 }
 

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "libwrapper.h"
-#include "inputfile_parse/CSPSpec.h"
-#include "minion.h"
 #include "command_search.h"
 #include "info_dumps.h"
+#include "inputfile_parse/CSPSpec.h"
+#include "minion.h"
 #include "solver.h"
 #include "system/minlib/exceptions.hpp"
 #include <iomanip>
@@ -20,7 +20,6 @@
 void doStandardSearch(CSPInstance& instance, SearchMethod args);
 void finaliseModel(CSPInstance& instance);
 
-
 extern Globals* globals;
 
 void resetMinion() {
@@ -29,7 +28,8 @@ void resetMinion() {
 }
 
 std::mutex global_minion_lock;
-ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance, bool(*callback)(void)) {
+ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance,
+                      bool (*callback)(void)) {
   std::lock_guard<std::mutex> guard(global_minion_lock);
   ReturnCodes returnCode = ReturnCodes::OK;
 
@@ -40,7 +40,6 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
    */
 
   resetMinion();
-
 
   // Redirect cout
   // https://stackoverflow.com/questions/49462524/controlling-output-from-external-libraries
@@ -56,8 +55,8 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
   filenameStream << put_time(gmtime(&rawtime), "%Y-%m-%d-%H:%M:%S");
   filenameStream << ".log";
 
-  logOutStream.open(filenameStream.str(),ios_base::app);
-  
+  logOutStream.open(filenameStream.str(), ios_base::app);
+
   cout.rdbuf(logOutStream.rdbuf());
 
   // Pass error codes across FFI boundaries, not exceptions.
@@ -75,12 +74,11 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
     getOptions().printLine("# Git version: \"" + tostring(GIT_VER) + "\"");
 
     GET_GLOBAL(global_random_gen).seed(args.randomSeed);
-     if(!getOptions().silent) {
-        cout << "#  Run at: UTC " << asctime(gmtime(&rawtime)) << endl;
-        cout << "# Input filename: " << getOptions().instance_name << endl;
-        getOptions().printLine("Using seed: " + tostring(args.randomSeed));
-        }
-      
+    if(!getOptions().silent) {
+      cout << "#  Run at: UTC " << asctime(gmtime(&rawtime)) << endl;
+      cout << "# Input filename: " << getOptions().instance_name << endl;
+      getOptions().printLine("Using seed: " + tostring(args.randomSeed));
+    }
 
     Parallel::setupAlarm(getOptions().timeoutActive, getOptions().time_limit,
                          getOptions().time_limit_is_CPUTime);
@@ -102,26 +100,22 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
     SetupCSPOrdering(instance, args);
     BuildCSP(instance);
 
-    //TODO (nd60): how to replace this??
+    // TODO (nd60): how to replace this??
     if(getOptions().commandlistIn != "") {
-       doCommandSearch(instance, args);
-     } else {
-       doStandardSearch(instance, args);
-     }
+      doCommandSearch(instance, args);
+    } else {
+      doStandardSearch(instance, args);
+    }
   }
 
   catch(parse_exception e) {
     cout << "Invalid instance: " << e.what() << endl;
-    returnCode =  ReturnCodes::INVALID_INSTANCE;
-  }
-  catch(...){
-    returnCode =  ReturnCodes::UNKNOWN_ERROR;
-  }
-
+    returnCode = ReturnCodes::INVALID_INSTANCE;
+  } catch(...) { returnCode = ReturnCodes::UNKNOWN_ERROR; }
 
   // Restore old cout
-  cout.rdbuf( oldCoutStreamBuf );
-  
+  cout.rdbuf(oldCoutStreamBuf);
+
   return returnCode;
 }
 
@@ -135,11 +129,9 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
   instance.allVars_list.push_back(makeVec(v));
 }
 
-
 Var constantAsVar(DomainInt constant) {
-  return Var(VAR_CONSTANT,constant);
+  return Var(VAR_CONSTANT, constant);
 }
-
 
 // Export of inline function get_constraint as bindings dont like inlines!
 ConstraintDef* lib_getConstraint(ConstraintType t) {
@@ -177,25 +169,22 @@ void finaliseModel(CSPInstance& instance) {
     instance.symOrder = instance.vars.getAllVars();
 
   if(instance.symOrder.size() != instance.vars.getAllVars().size()) {
-    //MAYBE_PARSER_INFO("Extending symmetry order with auxillery variables");
+    // MAYBE_PARSER_INFO("Extending symmetry order with auxillery variables");
     vector<Var> allVars = instance.vars.getAllVars();
     for(typename vector<Var>::iterator i = allVars.begin(); i != allVars.end(); ++i) {
-      if(find(instance.symOrder.begin(), instance.symOrder.end(), *i) ==
-         instance.symOrder.end())
+      if(find(instance.symOrder.begin(), instance.symOrder.end(), *i) == instance.symOrder.end())
         instance.symOrder.push_back(*i);
     }
   }
 
-  // 
+  //
   if(instance.symOrder.size() !=
      set<Var>(instance.symOrder.begin(), instance.symOrder.end()).size())
     throw parse_exception("SYMORDER cannot contain any variable more than once");
 
   if(instance.symOrder.size() != instance.vars.getAllVars().size())
     throw parse_exception("SYMORDER must contain every variable");
-
 }
-
 
 /*********************************************************************/
 /*                    REXPORTING INLINE FUNCTIONS                    */
@@ -217,8 +206,8 @@ ConstraintBlob* newConstraintBlob(ConstraintType constraint_type) {
   return new ConstraintBlob(lib_getConstraint(constraint_type));
 }
 
-SearchOrder* newSearchOrder(std::vector<Var>& vars,VarOrderEnum orderEnum, bool findOneSol) {
-  return new SearchOrder(vars,orderEnum,findOneSol);
+SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol) {
+  return new SearchOrder(vars, orderEnum, findOneSol);
 }
 
 void searchOptions_free(SearchOptions* searchOptions) {
@@ -247,9 +236,8 @@ Var getVarByName(CSPInstance& instance, char* name) {
 }
 
 void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2) {
-  newVar(instance, string(name), type, std::vector<DomainInt>({bound1,bound2}));
+  newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
 }
-
 
 void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder) {
   instance.searchOrder.push_back(searchOrder);
@@ -267,8 +255,26 @@ int printMatrix_getValue(int idx) {
   return checked_cast<int>(globals->state_m->getPrintMatrix()[idx][0].assignedValue());
 }
 
-void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars) {
+// mirrors MinionThreeInputReader::readGeneralConstraint, but over FFI.
+// look there for the why/how
+
+void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars) {
   constraint.vars.push_back(vars);
+}
+
+void constraint_addVar(ConstraintBlob& constraint, Var& var) {
+  constraint.vars.push_back(makeVec(var));
+}
+
+void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2) {
+  vector<Var> vars(2);
+  vars[0] = std::move(var1);
+  vars[1] = std::move(var2);
+  constraint.vars.push_back(std::move(vars));
+}
+
+void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant) {
+  constraint.constants.push_back(makeVec(constant));
 }
 
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants) {
@@ -277,6 +283,11 @@ void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainIn
 
 void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint) {
   constraint.internal_constraints.push_back(internal_constraint);
+}
+
+void constraint_addConstraintList(ConstraintBlob& constraint,
+                                  vector<ConstraintBlob>& internal_constraints) {
+  constraint.internal_constraints = std::move(internal_constraints);
 }
 
 std::vector<Var>* vec_var_new() {
@@ -294,16 +305,29 @@ void vec_var_free(std::vector<Var>* vec) {
 std::vector<DomainInt>* vec_int_new() {
   return new std::vector<DomainInt>();
 }
+
 void vec_int_push_back(std::vector<DomainInt>* vec, int n) {
   vec->push_back(n);
 }
-
 
 void vec_int_free(std::vector<DomainInt>* vec) {
   delete vec;
 }
 
-#endif
+std::vector<ConstraintBlob>* vec_constraints_new() {
+  return new std::vector<ConstraintBlob>();
+}
 
+// TODO: how to memory manage this?
+// move?
+void vec_constraints_push_back(std::vector<ConstraintBlob>* vec, ConstraintBlob& constraint) {
+  vec->push_back(std::move(constraint));
+}
+
+void vec_constraints_free(std::vector<ConstraintBlob>* vec) {
+  delete vec;
+}
+
+#endif
 
 // vim: cc=80 tw=80

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -73,6 +73,7 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
 
     globals->callback = callback;
     globals->options_m = new SearchOptions(options);
+    globals->options_m->findAllSolutions();
 
     getOptions().printLine("# " + std::string(MinionVersion));
     getOptions().printLine("# Git version: \"" + tostring(GIT_VER) + "\"");

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -261,6 +261,7 @@ int printMatrix_getValue(int idx);
 
 void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars);
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants);
+void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& inner_constraint);
 
 /***** std::vector Wrappers *****/
 std::vector<Var>* vec_var_new();

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -4,6 +4,7 @@
 #include "inputfile_parse/CSPSpec.h"
 #include "minion.h"
 #include "solver.h"
+#include "tuple_container.h"
 
 /*
  * Functions for using minion as a library.
@@ -122,8 +123,7 @@
  *  Reset all global variables in minion to their initial values.
  *
  */
-#include "minion.h"
-#include <vector>
+
 void resetMinion();
 
 enum ReturnCodes { OK, INVALID_INSTANCE, UNKNOWN_ERROR = 255 };
@@ -219,29 +219,23 @@ Var constantAsVar(DomainInt n);
  *    instance.constraints.push_back(leq);
  *    ```
  */
-ConstraintDef* lib_getConstraint(ConstraintType t);
 
-/***** Constructors *****/
-SearchOptions* newSearchOptions();
-SearchMethod* newSearchMethod();
-CSPInstance* newInstance();
-ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
-SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol);
-
-/***** Destructors *****/
-void searchOptions_free(SearchOptions* searchOptions);
-void searchMethod_free(SearchMethod* searchMethod);
-void instance_free(CSPInstance* instance);
-void constraint_free(ConstraintBlob* constraint);
-void searchOrder_free(SearchOrder* searchOrder);
-
-/***** Variable Helper Functions *****/
+/***** Variable *****/
 Var getVarByName(CSPInstance& instance, char* name);
 void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2);
 
-/***** Class member functions *****/
+/***** Tuple *****/
+TupleList* tupleList_new(vector<vector<DomainInt>>& tupleList);
+void tupleList_free(TupleList* tupleList);
+
+/***** Instance *****/
+CSPInstance* newInstance();
+void instance_free(CSPInstance* instance);
+
 void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder);
 void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
+void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist);
+TupleList* instance_getTupleTableSymbol(CSPInstance& instance, char* name);
 
 /*
  * printMatrix_* functions assume the print matrix is of the form
@@ -256,6 +250,10 @@ int printMatrix_getValue(int idx);
 
 // as per MinionThreeInput.h and build/src/Constraintdefs.h.
 
+ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
+void constraint_free(ConstraintBlob* constraint);
+
+ConstraintDef* lib_getConstraint(ConstraintType t);
 void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars);
 void constraint_addVar(ConstraintBlob& constraint, Var& var);
 void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2);
@@ -267,7 +265,22 @@ void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& intern
 void constraint_addConstraintList(ConstraintBlob& constraint,
                                   vector<ConstraintBlob>& internal_constraints);
 
+// Note that adding tuples to the symbol table is optional, but useful!
+// A constraint only has one tuple list.
+void constraint_setTuples(ConstraintBlob& constraint, TupleList* tupleList);
+
+/***** Small misc useful types *****/
+
+SearchOptions* newSearchOptions();
+SearchMethod* newSearchMethod();
+SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol);
+
+void searchOptions_free(SearchOptions* searchOptions);
+void searchMethod_free(SearchMethod* searchMethod);
+void searchOrder_free(SearchOrder* searchOrder);
+
 /***** std::vector Wrappers *****/
+
 std::vector<Var>* vec_var_new();
 void vec_var_push_back(std::vector<Var>* vec, Var var);
 void vec_var_free(std::vector<Var>* vec);
@@ -279,6 +292,11 @@ void vec_int_free(std::vector<DomainInt>* vec);
 std::vector<ConstraintBlob>* vec_constraints_new();
 void vec_constraints_push_back(std::vector<ConstraintBlob>* vec, ConstraintBlob& constraint);
 void vec_constraints_free(std::vector<ConstraintBlob>* vec);
+
+std::vector<std::vector<DomainInt>>* vec_vec_int_new();
+void vec_vec_int_push_back(std::vector<std::vector<DomainInt>>* vec,
+                           std::vector<DomainInt> new_elem);
+void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec);
 
 #endif
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -1,6 +1,5 @@
 // Minion https://github.com/minion/minion
 // SPDX-License-Identifier: MPL-2.0
-
 #include "ConstraintEnum.h"
 #include "inputfile_parse/CSPSpec.h"
 #include "minion.h"
@@ -12,7 +11,7 @@
  * Primarily for use by the Rust bindings - the library abstractions provided
  * here are neither complete nor safe.
  *
- * The Rust bindings (https://github.com/conjure-cp/conjure-oxide/tree/main/solvers/minion) 
+ * The Rust bindings (https://github.com/conjure-cp/conjure-oxide/tree/main/solvers/minion)
  * should provide a safe but low-level way to use Minion as a library.
  */
 
@@ -37,13 +36,13 @@
  * ineq(x, y, -1)
  * **EOF**
  *
- *  
+ *
  * CSPInstance instance;
- * 
+ *
  * std::vector<DomainInt> domainx = {1,3};
  * std::vector<DomainInt> domainy = {2,4};
  * std::vector<DomainInt> domainz = {1,5};
- * 
+ *
  * // **VARIABLES**
  * newVar(instance,"x",VAR_DISCRETE,domainx);
  * newVar(instance,"y",VAR_DISCRETE,domainy);
@@ -54,7 +53,7 @@
  * Var z = instance.vars.getSymbol("z");
  *
  * // **SEARCH**
- * 
+ *
  * // PRINT
  * instance.print_matrix.push_back({x});
  * instance.print_matrix.push_back({y});
@@ -68,16 +67,16 @@
 
 
  * // **CONSTRAINTS**
- * 
+ *
  * ConstraintBlob leq(lib_getConstraint(ConstraintType::CT_LEQSUM));
  * ConstraintBlob geq(lib_getConstraint(ConstraintType::CT_GEQSUM));
  * ConstraintBlob ineq(lib_getConstraint(ConstraintType::CT_INEQ));
 
- * 
+ *
  * // leq: [var] var
  * leq.vars.push_back({x,y,z});
  * leq.vars.push_back({constantAsVar(4)});
- *                     
+ *
  * geq.vars.push_back({x,y,z});
  * geq.vars.push_back({constantAsVar(4)});
 
@@ -94,11 +93,11 @@
 /* ADDING CONSTRAINTS
  * ==================
  *
- * You need to know the types of the arguments to the constraints being used 
+ * You need to know the types of the arguments to the constraints being used
  * and add things to the right vectors, or Minion will segfault.
  *
  * (types can be found in bin/src/build_constraints.h).
- 
+
  * Note the different vectors used to add different arguments based on type in
  * the above example.
  *
@@ -127,11 +126,7 @@
 #include <vector>
 void resetMinion();
 
-enum ReturnCodes {
-  OK,
-  INVALID_INSTANCE,
-  UNKNOWN_ERROR=255
-};
+enum ReturnCodes { OK, INVALID_INSTANCE, UNKNOWN_ERROR = 255 };
 
 /*
  * int runMinion:
@@ -143,15 +138,15 @@ enum ReturnCodes {
  *
  *   An error code is returned. These are described in ReturnCodes.
  */
-ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance, bool(*callback)(void));
+ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPInstance& instance,
+                      bool (*callback)(void));
 
-
-/* 
+/*
  * void newVar:
- *  
+ *
  *  Add a named variable to `instance`.
  *
- *  Once created, the variable can be accessed by calling 
+ *  Once created, the variable can be accessed by calling
  *  `instance.vars.getSymbol(name)`.
  *
  * Throws parse_exception if the variable is invalid, or the name is already
@@ -159,9 +154,9 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
  */
 void newVar(CSPInstance& instance, string name, VariableType type, vector<DomainInt> bounds);
 
-/* 
+/*
  * Var constantAsVar(DomainInt constant):
- *   
+ *
  *   Returns a constant as an anomynous variable, for use in constraints which
  *   take variables as arguments.
  *
@@ -177,7 +172,7 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
  *    Var x = instance.vars.getSymbol("x");
  *    Var y = instance.vars.getSymbol("y");
  *    Var z = instance.vars.getSymbol("z");
- *    
+ *
  *    leq.vars.push_back({x,y,z});
  *    leq.vars.push_back(constantAsVar(4));
  *
@@ -187,8 +182,6 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
  *    in the instance (such as the symbol table, or allVars).
  */
 Var constantAsVar(DomainInt n);
-
-
 
 /*******************************************************/
 /*                    FFI FUNCTIONS                    */
@@ -211,7 +204,7 @@ Var constantAsVar(DomainInt n);
 
 /*
  * ConstraintDef* lib_getConstraint:
- *  
+ *
  *  Get the constraint definition for the given ConstraintType.
  *  This is mainly required to define a ConstraintBlob for a model.
  *
@@ -233,7 +226,7 @@ SearchOptions* newSearchOptions();
 SearchMethod* newSearchMethod();
 CSPInstance* newInstance();
 ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
-SearchOrder* newSearchOrder(std::vector<Var>& vars,VarOrderEnum orderEnum, bool findOneSol);
+SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol);
 
 /***** Destructors *****/
 void searchOptions_free(SearchOptions* searchOptions);
@@ -259,9 +252,20 @@ void printMatrix_addVar(CSPInstance& instance, Var var);
 // Should be called only when minion has results in a callback.
 int printMatrix_getValue(int idx);
 
-void constraint_addVarList(ConstraintBlob& constraint, std::vector<Var>& vars);
+/***** Constraint argument parse types ****/
+
+// as per MinionThreeInput.h and build/src/Constraintdefs.h.
+
+void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars);
+void constraint_addVar(ConstraintBlob& constraint, Var& var);
+void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2);
+
+void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant);
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants);
-void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& inner_constraint);
+
+void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint);
+void constraint_addConstraintList(ConstraintBlob& constraint,
+                                  vector<ConstraintBlob>& internal_constraints);
 
 /***** std::vector Wrappers *****/
 std::vector<Var>* vec_var_new();
@@ -271,6 +275,10 @@ void vec_var_free(std::vector<Var>* vec);
 std::vector<DomainInt>* vec_int_new();
 void vec_int_push_back(std::vector<DomainInt>* vec, int n);
 void vec_int_free(std::vector<DomainInt>* vec);
+
+std::vector<ConstraintBlob>* vec_constraints_new();
+void vec_constraints_push_back(std::vector<ConstraintBlob>* vec, ConstraintBlob& constraint);
+void vec_constraints_free(std::vector<ConstraintBlob>* vec);
 
 #endif
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -126,7 +126,12 @@
 
 void resetMinion();
 
-enum ReturnCodes { OK, INVALID_INSTANCE, UNKNOWN_ERROR = 255 };
+enum ReturnCodes
+{
+  OK,
+  INVALID_INSTANCE,
+  UNKNOWN_ERROR = 255
+};
 
 /*
  * int runMinion:
@@ -229,7 +234,7 @@ TupleList* tupleList_new(vector<vector<DomainInt>>& tupleList);
 void tupleList_free(TupleList* tupleList);
 
 /***** Instance *****/
-CSPInstance* newInstance();
+CSPInstance* instance_new();
 void instance_free(CSPInstance* instance);
 
 void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder);
@@ -250,7 +255,7 @@ int printMatrix_getValue(int idx);
 
 // as per MinionThreeInput.h and build/src/Constraintdefs.h.
 
-ConstraintBlob* newConstraintBlob(ConstraintType contraint_type);
+ConstraintBlob* constraint_new(ConstraintType contraint_type);
 void constraint_free(ConstraintBlob* constraint);
 
 ConstraintDef* lib_getConstraint(ConstraintType t);
@@ -271,9 +276,9 @@ void constraint_setTuples(ConstraintBlob& constraint, TupleList* tupleList);
 
 /***** Small misc useful types *****/
 
-SearchOptions* newSearchOptions();
-SearchMethod* newSearchMethod();
-SearchOrder* newSearchOrder(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol);
+SearchOptions* searchOptions_new();
+SearchMethod* searchMethod_new();
+SearchOrder* searchOrder_new(std::vector<Var>& vars, VarOrderEnum orderEnum, bool findOneSol);
 
 void searchOptions_free(SearchOptions* searchOptions);
 void searchMethod_free(SearchMethod* searchMethod);


### PR DESCRIPTION
This PR adds support for "constraints in constraints" and tuples in the FFI bindings.
This means that all constraints can be built from Rust, except the couple that use short tuples.

See the commit log for a full changelist.

**Testing**
Tuples haven't been tested yet, but constraints in constraints has been tested to work in Rust on my machine, using `watchedor_reifyimply_1` (from Minions test_instances) as a test case. https://github.com/niklasdewally/conjure-oxide/blob/more_minion/solvers/minion/tests/test_watchedor_reifyimply_1.rs


**Future Work**
Once all the constraints work in Rust (not far away :) ), I will look further at memory management, settings passing, and short tuples. In particular, I am not sure what I am moving, what I am copying, and what I am just using references to (to use Rust-like terminology). However, it doesn't segfault now so I think it's fine.