### PR TITLE
libminion: replace DomainInt with int to fix debug usage

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -137,9 +137,9 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
   instance.allVars_list.push_back(makeVec(v));
 }
 
-Var constantAsVar(DomainInt constant)
+Var constantAsVar(int constant)
 {
-  return Var(VAR_CONSTANT, constant);
+  return Var(VAR_CONSTANT, (DomainInt)constant);
 }
 
 // Export of inline function get_constraint as bindings dont like inlines!
@@ -348,9 +348,9 @@ void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2)
   constraint.vars.push_back(std::move(vars));
 }
 
-void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant)
+void constraint_addConstant(ConstraintBlob& constraint, int constant)
 {
-  constraint.constants.push_back(makeVec(constant));
+  constraint.constants.push_back(makeVec((DomainInt)constant));
 }
 
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants)

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -186,7 +186,7 @@ void newVar(CSPInstance& instance, string name, VariableType type, vector<Domain
  *    Unlike variables created using newVar, these do not appear anywhere else
  *    in the instance (such as the symbol table, or allVars).
  */
-Var constantAsVar(DomainInt n);
+Var constantAsVar(int n);
 
 /*******************************************************/
 /*                    FFI FUNCTIONS                    */
@@ -263,7 +263,7 @@ void constraint_addList(ConstraintBlob& constraint, std::vector<Var>& vars);
 void constraint_addVar(ConstraintBlob& constraint, Var& var);
 void constraint_addTwoVars(ConstraintBlob& constraint, Var& var1, Var& var2);
 
-void constraint_addConstant(ConstraintBlob& constraint, DomainInt& constant);
+void constraint_addConstant(ConstraintBlob& constraint, int constant);
 void constraint_addConstantList(ConstraintBlob& constraint, std::vector<DomainInt>& constants);
 
 void constraint_addConstraint(ConstraintBlob& constraint, ConstraintBlob& internal_constraint);


### PR DESCRIPTION
In debug mode, DomainInt is a Wrapper<int>, not an int. This would break FFI functions that take a DomainInt when the library is compiled in debug mode.

To fix this, ints are took as input instead of DomainInts, and are cast to a DomainInt internally. This cast adds a Wrapper to the int if necessary.