### PR TITLE
Libminion: get value out of Tableout

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -442,6 +442,29 @@ void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec)
   delete vec;
 }
 
+char* TableOut_get(char* key) {
+  try {
+    /*
+     * .data() doesn't copy, it just returns a ptr to the internal
+     * representation of the string . As we are interfacing with C and using 
+     * char*, I will just malloc strcpy here (even though it might not be 
+     * idiomatic C++?)
+     *
+     * It needs this many temporary variables due to memory shenanigans!
+     */
+
+    string val_str = getTableOut().get(key);
+    const char* val = val_str.data();
+
+    char* heaped_val = (char*) std::malloc(strlen(val) +1);
+    strcpy(heaped_val,val);
+    return heaped_val;
+
+  } catch(std::out_of_range) {
+    return NULL;
+  }
+}
+
 #endif
 
 // vim: cc=80 tw=80

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -431,6 +431,33 @@ void vec_vec_int_push_back(std::vector<std::vector<DomainInt>>* vec,
 /// Frees the given `vector<vector<DomainInt>`.
 void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec);
 
+/***** TableOut *****/
+
+/* These functions access the TableOut: a logging class used to store
+ * run statistics about Minion.
+ *
+ * TableOut is a global singleton.
+ *
+ *
+ * Useful Values
+ * =============
+ * Here are some values stored in the table.
+ * This is not an exhaustive list.
+ *
+ * "Nodes" - the number of nodes used.
+ * "Satisfiable" - was the model satisfiable or not?
+ * "SolutionsFound" - number of solutions found
+ * "RandomSeed" - the random seed used.
+ */
+
+/// Gets the value for key from the table.
+///
+/// If there is no such element,
+///
+/// Memory Management:
+///   The returned pointer must be freed by the user.
+char* TableOut_get(char* key); 
+
 #endif
 
 // vim: cc=80 tw=80

--- a/minion/system/tableout.h
+++ b/minion/system/tableout.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <stdexcept>
 #include <stdlib.h>
 #include <string>
 #include <utility>
@@ -60,6 +61,12 @@ public:
     for(it = data.begin(); it != data.end(); it++) {
       json.mapElement(it->first, it->second);
     }
+  }
+
+  /// Gets the value (as a string) for the given key.
+  /// Throws an std::out_of_range exception if key is not in the TableOut.
+  string get(string key) {
+      return data.at(key);
   }
 
   void print_table_line() {


### PR DESCRIPTION
This PR adds:

1. a getter for TableOut, allowing access to its values. This wraps the standard map.at() method.
2. a FFI function to get values out of the singleton global TableOut.


This has been used in the rust bindings to successfully get the node count out of minion (https://github.com/conjure-cp/conjure-oxide/pull/281)

@ChrisJefferson 