### PR TITLE
docs: update `pow` docs

### DIFF
--- a/sphinxdocs/usage/constraints.rst
+++ b/sphinxdocs/usage/constraints.rst
@@ -453,9 +453,10 @@ pow
 
 The constraint ``pow(x,y,z)``
 
-ensures that x^y=z.
+Ensures that x^y=z. This constraint is false when `y<0` except for `1^y=1` and
+`(-1)^y=z` (where z is 1 if `y` is odd and z is -1 if `y` is even).
 
-This constraint is only available for positive domains x, y and z.
+This constraint is more efficient when x, y and z have positive domains.
 
 
 sumleq


### PR DESCRIPTION
@ChrisJefferson 

Update documentation for `pow` to have the correct semantics for negative numbers. 

See https://github.com/minion/minion/issues/40.
