### PR TITLE
Add readthedocs link to README

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,8 @@
 If you have downloaded a binary for your OS, the minion binary will be in the
 'bin' directory. 
 
-the "docs" directory contains a full manual for Minion. 
+The "docs" directory contains a full manual for Minion. This 
+can also be found online at https://minion-solver.readthedocs.org/.
 The "benchmarks" directory contains a range of example programs.
 The "generators" directory contains a number of generators, these are
 in general poorly documented.


### PR DESCRIPTION
It is not obvious at first glance that there is a readthedocs site for Minion. This should make the docs easier to find :)

It might also be good to add it as Minion's website link in the Github sidebar?