### PR TITLE
fix(libminion): also clear Minion memory at end of runMinion()

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -127,6 +127,8 @@ ReturnCodes runMinion(SearchOptions& options, SearchMethod& args, ProbSpec::CSPI
   // Restore old cout
   cout.rdbuf(oldCoutStreamBuf);
 
+  resetMinion();
+  
   return returnCode;
 }
 


### PR DESCRIPTION
This stops the memory allocated by Minion hanging around until the next
time Minion is called.
