### PR TITLE
Added addconstraint midsearch interface + off by one fix

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -260,6 +260,16 @@ void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint)
   instance.constraints.push_back(constraint);
 }
 
+bool instance_addConstraintMidsearch(CSPInstance& instance, ConstraintBlob& constraint)
+{
+  // Keep a stable copy of the blob alive for the lifetime of `instance`.
+  // Some built constraints may retain references to blob-owned argument storage.
+  instance.constraints.push_back(constraint);
+
+  AbstractConstraint* c = build_constraint(instance.constraints.back());
+  return getState().addConstraintMidsearch(c);
+}
+
 void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist)
 {
   instance.addTableSymbol(name, std::shared_ptr<TupleList>(tuplelist));

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -254,6 +254,14 @@ void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder);
 ///   * `constraint` is copied into `instance`.
 void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
 
+/// Adds a constraint to the currently running search and propagates it.
+///
+/// Returns `false` if adding the constraint causes immediate failure.
+///
+/// This must only be called while Minion is actively searching.
+bool instance_addConstraintMidsearch(CSPInstance& instance, ConstraintBlob& constraint);
+
+
 /// Adds a named tuple-table to a model instance.
 ///
 /// Memory Management:

--- a/minion/solver.h
+++ b/minion/solver.h
@@ -142,7 +142,7 @@ public:
     return constraints;
   }
 
-  void addConstraintMidsearch(AbstractConstraint* c);
+  bool addConstraintMidsearch(AbstractConstraint* c);
   void redoFullPropagate(AbstractConstraint* c);
 
   long long int getSolutionCount() {

--- a/minion/solver.hpp
+++ b/minion/solver.hpp
@@ -80,13 +80,15 @@ inline bool SearchState::addConstraint(AbstractConstraint* c) {
   return true;
 }
 
-inline void SearchState::addConstraintMidsearch(AbstractConstraint* c) {
-  addConstraint(c);
+inline bool SearchState::addConstraintMidsearch(AbstractConstraint* c) {
+  bool ret = addConstraint(c);
   c->setup();
   redoFullPropagate(c);
+
+  return ret;
 }
 
 inline void SearchState::redoFullPropagate(AbstractConstraint* c) {
-  constraintsToPropagate[Controller::getWorldDepth()].insert(c);
+  constraintsToPropagate[Controller::getWorldDepth()-1].insert(c);
   c->fullPropagate();
 }


### PR DESCRIPTION
Changed the interface slightly for the midsearch constraint function to return bool rather than void, no reason to lose that piece of information if we have it on hand.

Fixed off-by-one segfaulting error in the function, solving [Issue #51](https://github.com/minion/minion/issues/51)

Added library wrapper.