### PR TITLE
ffi: add pointer-based vec_vec_int push wrapper

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -445,6 +445,12 @@ void vec_vec_int_push_back(std::vector<std::vector<DomainInt>>* vec,
   vec->push_back(new_elem);
 }
 
+void vec_vec_int_push_back_ptr(std::vector<std::vector<DomainInt>>* vec,
+                               std::vector<DomainInt>* new_elem)
+{
+  vec->push_back(*new_elem);
+}
+
 void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec)
 {
   delete vec;

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -427,6 +427,8 @@ std::vector<std::vector<DomainInt>>* vec_vec_int_new();
 ///   `new_elem` is copied into `vec`.
 void vec_vec_int_push_back(std::vector<std::vector<DomainInt>>* vec,
                            std::vector<DomainInt> new_elem);
+void vec_vec_int_push_back_ptr(std::vector<std::vector<DomainInt>>* vec,
+                               std::vector<DomainInt>* new_elem);
 
 /// Frees the given `vector<vector<DomainInt>`.
 void vec_vec_int_free(std::vector<std::vector<DomainInt>>* vec);


### PR DESCRIPTION
this seems to be missing - any reason not to have it?

needed in conjure-cp/conjure-oxide#775