### PR TITLE
Test midsearch mutations

### DIFF
--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -26,6 +26,16 @@ void finaliseModel(CSPInstance& instance);
 
 extern thread_local Globals* globals;
 
+static thread_local std::string ffi_error_message;
+
+static void set_error(const std::string& msg) {
+  ffi_error_message = msg;
+}
+
+const char* minion_error_message() {
+  return ffi_error_message.c_str();
+}
+
 // RAII guard: sets globals on construction, clears on destruction.
 // If globals is already set to ctx (e.g. callback re-entry), this is a no-op.
 // Asserts if globals is set to a *different* context (re-entrant call with wrong ctx).
@@ -85,13 +95,13 @@ void minion_deactivateContext()
   globals = nullptr;
 }
 
-ReturnCodes runMinion(MinionContext* ctx, SearchOptions& options, SearchMethod& args,
-                      ProbSpec::CSPInstance& instance,
-                      bool (*callback)(MinionContext* ctx, void* userdata),
-                      void* userdata)
+MinionResult runMinion(MinionContext* ctx, SearchOptions& options, SearchMethod& args,
+                       ProbSpec::CSPInstance& instance,
+                       bool (*callback)(MinionContext* ctx, void* userdata),
+                       void* userdata)
 {
   ContextGuard guard(ctx);
-  ReturnCodes returnCode = ReturnCodes::OK;
+  MinionResult returnCode = MinionResult::MINION_OK;
 
   /*
    * Adapted from minion_main.
@@ -178,18 +188,26 @@ ReturnCodes runMinion(MinionContext* ctx, SearchOptions& options, SearchMethod& 
 
   catch(const parse_exception& e) {
     cout << "Invalid instance: " << e.what() << endl;
-    returnCode = ReturnCodes::INVALID_INSTANCE;
+    set_error(e.what());
+    returnCode = MinionResult::MINION_INVALID_INSTANCE;
   } catch(const std::bad_alloc&) {
-    returnCode = ReturnCodes::MEMORY_ERROR;
+    set_error("out of memory");
+    returnCode = MinionResult::MINION_MEMORY_ERROR;
+  } catch(const std::exception& e) {
+    set_error(e.what());
+    returnCode = MinionResult::MINION_UNKNOWN_ERROR;
   } catch(...) {
-    returnCode = ReturnCodes::UNKNOWN_ERROR;
+    set_error("unknown exception");
+    returnCode = MinionResult::MINION_UNKNOWN_ERROR;
   }
 
   // Detect timeout: doStandardSearch sets TableOut "TimeOut" to 1
-  if(returnCode == ReturnCodes::OK && ctx->tableOut_m) {
+  if(returnCode == MinionResult::MINION_OK && ctx->tableOut_m) {
     try {
-      if(getTableOut().get("TimeOut") == "1")
-        returnCode = ReturnCodes::TIMEOUT;
+      if(getTableOut().get("TimeOut") == "1") {
+        set_error("solver timed out");
+        returnCode = MinionResult::MINION_TIMEOUT;
+      }
     } catch(...) {}
   }
 
@@ -282,15 +300,32 @@ void finaliseModel(CSPInstance& instance)
 
 /***** Variable *****/
 
-Var getVarByName(CSPInstance& instance, char* name)
+VarResult minion_getVarByName(CSPInstance& instance, char* name)
 {
-
-  return instance.vars.getSymbol(string(name));
+  try {
+    Var v = instance.vars.getSymbol(string(name));
+    return {MinionResult::MINION_OK, v};
+  } catch(const parse_exception& e) {
+    set_error(e.what());
+    return {MinionResult::MINION_PARSE_ERROR, Var()};
+  } catch(const std::exception& e) {
+    set_error(e.what());
+    return {MinionResult::MINION_UNKNOWN_ERROR, Var()};
+  }
 }
 
-void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2)
+MinionResult minion_newVar(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2)
 {
-  newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
+  try {
+    newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
+    return MinionResult::MINION_OK;
+  } catch(const parse_exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_PARSE_ERROR;
+  } catch(const std::exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_UNKNOWN_ERROR;
+  }
 }
 
 /***** Tuple *****/
@@ -326,15 +361,28 @@ void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint)
   instance.constraints.push_back(constraint);
 }
 
-bool instance_addConstraintMidsearch(MinionContext* ctx, CSPInstance& instance, ConstraintBlob& constraint)
+MinionResult minion_addConstraintMidsearch(MinionContext* ctx, CSPInstance& instance, ConstraintBlob& constraint)
 {
-  ContextGuard guard(ctx);
-  // Keep a stable copy of the blob alive for the lifetime of `instance`.
-  // Some built constraints may retain references to blob-owned argument storage.
-  instance.constraints.push_back(constraint);
+  try {
+    ContextGuard guard(ctx);
+    // Keep a stable copy of the blob alive for the lifetime of `instance`.
+    // Some built constraints may retain references to blob-owned argument storage.
+    instance.constraints.push_back(constraint);
 
-  AbstractConstraint* c = build_constraint(instance.constraints.back());
-  return getState().addConstraintMidsearch(c);
+    AbstractConstraint* c = build_constraint(instance.constraints.back());
+    bool ok = getState().addConstraintMidsearch(c);
+    if(!ok) {
+      set_error("propagation failure when adding constraint midsearch");
+      return MinionResult::MINION_INVALID_INSTANCE;
+    }
+    return MinionResult::MINION_OK;
+  } catch(const parse_exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_PARSE_ERROR;
+  } catch(const std::exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_UNKNOWN_ERROR;
+  }
 }
 
 void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist)

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -359,6 +359,7 @@ CSPInstance* instance_new()
 
 void instance_free(CSPInstance* instance)
 {
+  assertNotInSearch("instance_free");
   delete instance;
 }
 
@@ -415,12 +416,17 @@ MinionResult minion_newVarMidsearch(MinionContext* ctx, CSPInstance& instance,
     case VAR_BOUND:
       getVars().boundVarContainer.addVariables(bounds, 1);
       break;
+    case VAR_DISCRETE:
+      getVars().bigRangeVarContainer.addVariables({{bound1, bound2}});
+      break;
+    case VAR_SPARSEBOUND:
+      getVars().sparseBoundVarContainer.addVariables({bound1, bound2}, 1);
+      break;
     case VAR_BOOL:
       getVars().boolVarContainer.addVariables(1);
       break;
     default:
-      set_error("minion_newVarMidsearch: only VAR_BOUND and VAR_BOOL "
-                "are supported mid-search");
+      set_error("minion_newVarMidsearch: unsupported variable type");
       return MinionResult::MINION_INVALID_ARGUMENT;
     }
 
@@ -436,6 +442,7 @@ MinionResult minion_newVarMidsearch(MinionContext* ctx, CSPInstance& instance,
 
 void instance_addTupleTableSymbol(CSPInstance& instance, char* name, TupleList* tuplelist)
 {
+  assertNotInSearch("instance_addTupleTableSymbol");
   instance.addTableSymbol(name, std::shared_ptr<TupleList>(tuplelist));
 }
 
@@ -447,6 +454,7 @@ TupleList* instance_getTupleTableSymbol(CSPInstance& instance, char* name)
 void instance_addShortTupleTableSymbol(CSPInstance& instance, char* name,
                                        ShortTupleList* shorttuplelist)
 {
+  assertNotInSearch("instance_addShortTupleTableSymbol");
   instance.addShortTableSymbol(name, std::shared_ptr<ShortTupleList>(shorttuplelist));
 }
 

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -36,6 +36,16 @@ const char* minion_error_message() {
   return ffi_error_message.c_str();
 }
 
+// Abort if called while search is active (globals != nullptr).
+// Pre-search-only functions should call this to prevent misuse from callbacks.
+static void assertNotInSearch(const char* funcName) {
+  if(globals != nullptr) {
+    fprintf(stderr, "FATAL: %s cannot be called during search. "
+                    "Use the *Midsearch variant instead.\n", funcName);
+    abort();
+  }
+}
+
 // RAII guard: sets globals on construction, clears on destruction.
 // If globals is already set to ctx (e.g. callback re-entry), this is a no-op.
 // Asserts if globals is set to a *different* context (re-entrant call with wrong ctx).
@@ -316,6 +326,7 @@ VarResult minion_getVarByName(CSPInstance& instance, char* name)
 
 MinionResult minion_newVar(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2)
 {
+  assertNotInSearch("minion_newVar");
   try {
     newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
     return MinionResult::MINION_OK;
@@ -353,11 +364,13 @@ void instance_free(CSPInstance* instance)
 
 void instance_addSearchOrder(CSPInstance& instance, SearchOrder& searchOrder)
 {
+  assertNotInSearch("instance_addSearchOrder");
   instance.searchOrder.push_back(searchOrder);
 }
 
 void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint)
 {
+  assertNotInSearch("instance_addConstraint");
   instance.constraints.push_back(constraint);
 }
 
@@ -375,6 +388,42 @@ MinionResult minion_addConstraintMidsearch(MinionContext* ctx, CSPInstance& inst
       set_error("propagation failure when adding constraint midsearch");
       return MinionResult::MINION_INVALID_INSTANCE;
     }
+    return MinionResult::MINION_OK;
+  } catch(const parse_exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_PARSE_ERROR;
+  } catch(const std::exception& e) {
+    set_error(e.what());
+    return MinionResult::MINION_UNKNOWN_ERROR;
+  }
+}
+
+MinionResult minion_newVarMidsearch(MinionContext* ctx, CSPInstance& instance,
+                                    char* name, VariableType type,
+                                    int bound1, int bound2)
+{
+  try {
+    ContextGuard guard(ctx);
+
+    // 1. Add to the spec (symbol table, allVars_list, etc.)
+    newVar(instance, string(name), type, std::vector<DomainInt>({bound1, bound2}));
+
+    // 2. Also register in the live runtime container so mid-search
+    //    constraints can reference this variable without segfaulting.
+    Bounds bounds(bound1, bound2);
+    switch(type) {
+    case VAR_BOUND:
+      getVars().boundVarContainer.addVariables(bounds, 1);
+      break;
+    case VAR_BOOL:
+      getVars().boolVarContainer.addVariables(1);
+      break;
+    default:
+      set_error("minion_newVarMidsearch: only VAR_BOUND and VAR_BOOL "
+                "are supported mid-search");
+      return MinionResult::MINION_INVALID_ARGUMENT;
+    }
+
     return MinionResult::MINION_OK;
   } catch(const parse_exception& e) {
     set_error(e.what());
@@ -408,6 +457,7 @@ ShortTupleList* instance_getShortTupleTableSymbol(CSPInstance& instance, char* n
 
 void printMatrix_addVar(CSPInstance& instance, Var var)
 {
+  assertNotInSearch("printMatrix_addVar");
   instance.print_matrix.push_back({var});
 }
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -325,6 +325,18 @@ void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
 /// The context must be the one that is currently running the search.
 #ifdef LIBMINION
 MinionResult minion_addConstraintMidsearch(MinionContext* ctx, CSPInstance& instance, ConstraintBlob& constraint);
+
+/// Adds a named variable to the instance and registers it in the live
+/// runtime solver containers so that subsequent mid-search constraints
+/// can reference it.
+///
+/// Only VAR_BOUND and VAR_BOOL are currently supported mid-search.
+///
+/// This must only be called while Minion is actively searching.
+/// The context must be the one that is currently running the search.
+MinionResult minion_newVarMidsearch(MinionContext* ctx, CSPInstance& instance,
+                                    char* name, VariableType type,
+                                    int bound1, int bound2);
 #endif
 
 

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -330,7 +330,8 @@ MinionResult minion_addConstraintMidsearch(MinionContext* ctx, CSPInstance& inst
 /// runtime solver containers so that subsequent mid-search constraints
 /// can reference it.
 ///
-/// Only VAR_BOUND and VAR_BOOL are currently supported mid-search.
+/// Supported types: VAR_BOUND, VAR_DISCRETE, VAR_SPARSEBOUND, VAR_BOOL.
+/// VAR_CONSTANT does not need this function — use constantAsVar() instead.
 ///
 /// This must only be called while Minion is actively searching.
 /// The context must be the one that is currently running the search.

--- a/minion/libwrapper.h
+++ b/minion/libwrapper.h
@@ -117,14 +117,38 @@
 #ifndef _WRAPPER_H
 #define _WRAPPER_H
 
-enum ReturnCodes
+/*
+ * MinionResult: error codes returned by fallible library functions.
+ *
+ * Functions that return MinionResult can fail; all other functions cannot.
+ * On failure, call minion_error_message() for a human-readable detail string
+ * (thread-local, valid until the next MinionResult-returning call).
+ */
+enum MinionResult
 {
-  OK,
-  INVALID_INSTANCE,
-  TIMEOUT,
-  MEMORY_ERROR,
-  UNKNOWN_ERROR = 255
+  MINION_OK = 0,
+  MINION_INVALID_INSTANCE = 1,
+  MINION_TIMEOUT = 2,
+  MINION_MEMORY_ERROR = 3,
+  MINION_PARSE_ERROR = 4,
+  MINION_INVALID_ARGUMENT = 5,
+  MINION_UNKNOWN_ERROR = 255
 };
+
+/*
+ * VarResult: returned by functions that produce a Var and can fail.
+ * Check .result before using .var.
+ */
+struct VarResult
+{
+  MinionResult result;
+  Var var;
+};
+
+/// Returns the error message for the most recent non-OK MinionResult
+/// on the current thread. The returned pointer is valid until the next
+/// MinionResult-returning call on the same thread.
+const char* minion_error_message();
 
 #ifdef LIBMINION
 
@@ -175,12 +199,12 @@ void minion_deactivateContext();
  *   Return true to continue searching, false to stop.
  *   Pass NULL for callback to find all solutions without a callback.
  *
- *   An error code is returned. These are described in ReturnCodes.
+ *   A MinionResult error code is returned.
  */
-ReturnCodes runMinion(MinionContext* ctx, SearchOptions& options, SearchMethod& args,
-                      ProbSpec::CSPInstance& instance,
-                      bool (*callback)(MinionContext* ctx, void* userdata),
-                      void* userdata);
+MinionResult runMinion(MinionContext* ctx, SearchOptions& options, SearchMethod& args,
+                       ProbSpec::CSPInstance& instance,
+                       bool (*callback)(MinionContext* ctx, void* userdata),
+                       void* userdata);
 
 #endif // LIBMINION
 
@@ -264,8 +288,8 @@ Var constantAsVar(int n);
  */
 
 /***** Variable *****/
-Var getVarByName(CSPInstance& instance, char* name);
-void newVar_ffi(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2);
+VarResult minion_getVarByName(CSPInstance& instance, char* name);
+MinionResult minion_newVar(CSPInstance& instance, char* name, VariableType type, int bound1, int bound2);
 
 /***** Tuple *****/
 TupleList* tupleList_new(vector<vector<DomainInt>>& tupleList);
@@ -294,12 +318,13 @@ void instance_addConstraint(CSPInstance& instance, ConstraintBlob& constraint);
 
 /// Adds a constraint to the currently running search and propagates it.
 ///
-/// Returns `false` if adding the constraint causes immediate failure.
+/// Returns MINION_OK on success, or an error code if adding the constraint
+/// causes immediate failure (e.g. propagation wipeout).
 ///
 /// This must only be called while Minion is actively searching.
 /// The context must be the one that is currently running the search.
 #ifdef LIBMINION
-bool instance_addConstraintMidsearch(MinionContext* ctx, CSPInstance& instance, ConstraintBlob& constraint);
+MinionResult minion_addConstraintMidsearch(MinionContext* ctx, CSPInstance& instance, ConstraintBlob& constraint);
 #endif
 
 

--- a/minion/variables/containers/intboundvar.h
+++ b/minion/variables/containers/intboundvar.h
@@ -352,20 +352,6 @@ struct BoundVarContainer {
       bound_ptr[2 * i] = initialBounds[i].first;
       bound_ptr[2 * i + 1] = initialBounds[i].second;
     }
-
-    DomainInt minDomainVal = 0;
-    DomainInt maxDomainVal = 0;
-    if(!initialBounds.empty()) {
-      minDomainVal = initialBounds[0].first;
-      maxDomainVal = initialBounds[0].second;
-      for(UnsignedSysInt i = old_varCount; i < varCount_m; ++i) {
-        bound_ptr[2 * i] = initialBounds[i].first;
-        bound_ptr[2 * i + 1] = initialBounds[i].second;
-
-        minDomainVal = mymin(initialBounds[i].first, minDomainVal);
-        maxDomainVal = mymax(initialBounds[i].second, maxDomainVal);
-      }
-    }
   }
 
   vector<AbstractConstraint*>* getConstraints(const BoundVarRef_internal<BoundType>& b) {

--- a/minion/variables/containers/long_intvar.h
+++ b/minion/variables/containers/long_intvar.h
@@ -48,8 +48,6 @@ struct BigRangeVarContainer {
 
   BigRangeVarContainer()
       : bms_array(&getMemory().monotonicSet()), triggerList(false), varCount_m(0) {
-    // Store where the first variable will go.
-    varOffset.push_back(0);
   }
 
   typedef DomainInt domainBound_type;
@@ -139,41 +137,43 @@ struct BigRangeVarContainer {
   }
 
   void addVariables(const vector<Bounds>& newDomains) {
+    SysInt old_varCount = varCount_m;
+
     for(SysInt i = 0; i < (SysInt)newDomains.size(); ++i) {
       initialBounds.push_back(make_pair(newDomains[i].lowerBound, newDomains[i].upperBound));
-      DomainInt domainSize;
-      domainSize = newDomains[i].upperBound - newDomains[i].lowerBound + 1;
-      varOffset.push_back(varOffset.back() + domainSize);
+      DomainInt domainSize = newDomains[i].upperBound - newDomains[i].lowerBound + 1;
+
+      // Allocate bms storage for this variable and compute its varOffset.
+      // varOffset[j] + value == absolute bms position for domain value 'value'.
+      DomainInt bmsPos = bms_array->request_storage(domainSize);
+      varOffset.push_back(bmsPos - newDomains[i].lowerBound);
+
       varCount_m++;
     }
-    constraints.resize(newDomains.size());
+
+    constraints.resize(varCount_m);
 #ifdef WDEG
-    wdegs.resize(newDomains.size());
+    wdegs.resize(varCount_m);
 #endif
 
-    bound_data = getMemory().backTrack().requestBytesExtendable(varCount_m * BOUND_DATA_SIZE *
-                                                                sizeof(domainBound_type));
-    DomainInt temp1 = bms_array->request_storage(varOffset.back());
-
-    // correct varOffsets to start at the start of our block.
-    if(temp1 > 0) {
-      for(SysInt i = 0; i < (SysInt)varOffset.size(); ++i)
-        varOffset[i] += temp1;
+    if(bound_data.empty()) {
+      bound_data = getMemory().backTrack().requestBytesExtendable(
+          varCount_m * BOUND_DATA_SIZE * sizeof(domainBound_type));
+    } else {
+      getMemory().backTrack().resizeExtendableBlock(
+          bound_data, varCount_m * BOUND_DATA_SIZE * sizeof(domainBound_type));
     }
 
-    for(SysInt j = 0; j < (SysInt)varCount_m; ++j) {
-      varOffset[j] = varOffset[j] - initialBounds[j].first;
-    };
-
     domainBound_type* bound_ptr = (domainBound_type*)(bound_data());
-
-    for(UnsignedSysInt i = 0; i < varCount_m; ++i) {
+    for(UnsignedSysInt i = old_varCount; i < varCount_m; ++i) {
       bound_ptr[BOUND_DATA_SIZE * i] = initialBounds[i].first;
       bound_ptr[BOUND_DATA_SIZE * i + 1] = initialBounds[i].second;
       bound_ptr[BOUND_DATA_SIZE * i + 2] = initialBounds[i].second - initialBounds[i].first + 1;
     }
 
-    triggerList.addVariables(initialBounds);
+    vector<pair<DomainInt, DomainInt>> newBounds(
+        initialBounds.begin() + old_varCount, initialBounds.end());
+    triggerList.addVariables(newBounds);
   }
 
   BOOL isAssigned(BigRangeVarRef_internal d) const {

--- a/minion/variables/containers/long_intvar.h
+++ b/minion/variables/containers/long_intvar.h
@@ -167,18 +167,10 @@ struct BigRangeVarContainer {
 
     domainBound_type* bound_ptr = (domainBound_type*)(bound_data());
 
-    DomainInt minDomainVal = 0;
-    DomainInt maxDomainVal = 0;
-    if(!initialBounds.empty()) {
-      minDomainVal = initialBounds[0].first;
-      maxDomainVal = initialBounds[0].second;
-      for(UnsignedSysInt i = 0; i < varCount_m; ++i) {
-        bound_ptr[BOUND_DATA_SIZE * i] = initialBounds[i].first;
-        bound_ptr[BOUND_DATA_SIZE * i + 1] = initialBounds[i].second;
-        bound_ptr[BOUND_DATA_SIZE * i + 2] = initialBounds[i].second - initialBounds[i].first + 1;
-        minDomainVal = mymin(initialBounds[i].first, minDomainVal);
-        maxDomainVal = mymax(initialBounds[i].second, maxDomainVal);
-      }
+    for(UnsignedSysInt i = 0; i < varCount_m; ++i) {
+      bound_ptr[BOUND_DATA_SIZE * i] = initialBounds[i].first;
+      bound_ptr[BOUND_DATA_SIZE * i + 1] = initialBounds[i].second;
+      bound_ptr[BOUND_DATA_SIZE * i + 2] = initialBounds[i].second - initialBounds[i].first + 1;
     }
 
     triggerList.addVariables(initialBounds);

--- a/minion/variables/containers/sparse_intboundvar.h
+++ b/minion/variables/containers/sparse_intboundvar.h
@@ -135,9 +135,6 @@ struct SparseBoundVarContainer {
 
     SysInt oldCount = varCount_m;
 
-    DomainInt minDomainVal = DomainInt_Min;
-    DomainInt maxDomainVal = DomainInt_Max;
-
     D_ASSERT(bounds.front() >= DomainInt_Min);
     D_ASSERT(bounds.back() <= DomainInt_Max);
 
@@ -152,9 +149,6 @@ struct SparseBoundVarContainer {
     domains.push_back(tDom);
     for(SysInt j = 0; j < count; ++j)
       domain_reference.push_back(domains.size() - 1);
-
-    minDomainVal = mymin(tDom.front(), minDomainVal);
-    maxDomainVal = mymax(tDom.back(), maxDomainVal);
 
     // TODO: Setting varCount_m to avoid changing other code.. long term, do
     // we need it?

--- a/test_instances/test_multithread.cpp
+++ b/test_instances/test_multithread.cpp
@@ -159,6 +159,159 @@ int expected_bounded_sum(int k, int n, int bound) {
     return count;
 }
 
+// ---- Mid-search mutation tests ----
+
+enum MidsearchScenario {
+    MID_BULK_ADD_AND_CONSTRAIN,
+    MID_MULTI_CALLBACK_ADD_AND_CONSTRAIN,
+    MID_DUPLICATE_NAME_ACROSS_CALLBACKS
+};
+
+struct MidsearchState {
+    MidsearchScenario scenario;
+    CSPInstance* instance;
+    int callback_count = 0;
+    int added_count = 0;
+    int constrained_count = 0;
+    bool all_ok = true;
+    MinionResult duplicate_second_add = MINION_OK;
+};
+
+bool midsearch_callback(MinionContext* ctx, void* userdata) {
+    MidsearchState* state = reinterpret_cast<MidsearchState*>(userdata);
+    state->callback_count++;
+
+    VarResult x_res = minion_getVarByName(*state->instance, (char*)"x");
+    if(x_res.result != MINION_OK) {
+        state->all_ok = false;
+        return false;
+    }
+
+    if(state->scenario == MID_BULK_ADD_AND_CONSTRAIN) {
+        // Add and constrain many variables in one callback.
+        for(int i = 0; i < 40; i++) {
+            std::string name = "mid_bulk_" + std::to_string(i);
+            MinionResult add_res = minion_newVarMidsearch(ctx, *state->instance, (char*)name.c_str(),
+                                                          VAR_BOUND, 0, 3);
+            if(add_res != MINION_OK) {
+                state->all_ok = false;
+                break;
+            }
+            state->added_count++;
+
+            VarResult v_res = minion_getVarByName(*state->instance, (char*)name.c_str());
+            if(v_res.result != MINION_OK) {
+                state->all_ok = false;
+                break;
+            }
+
+            ConstraintBlob eq(lib_getConstraint(CT_EQ));
+            eq.vars.push_back({v_res.var});
+            eq.vars.push_back({x_res.var});
+            MinionResult con_res = minion_addConstraintMidsearch(ctx, *state->instance, eq);
+            if(con_res != MINION_OK) {
+                state->all_ok = false;
+                break;
+            }
+            state->constrained_count++;
+        }
+        return false;
+    }
+
+    if(state->scenario == MID_MULTI_CALLBACK_ADD_AND_CONSTRAIN) {
+        // Add one variable each callback and keep searching for a few callbacks.
+        std::string name = "mid_step_" + std::to_string(state->callback_count);
+        MinionResult add_res =
+            minion_newVarMidsearch(ctx, *state->instance, (char*)name.c_str(), VAR_BOUND, 0, 2);
+        if(add_res != MINION_OK) {
+            state->all_ok = false;
+            return false;
+        }
+        state->added_count++;
+
+        VarResult v_res = minion_getVarByName(*state->instance, (char*)name.c_str());
+        if(v_res.result != MINION_OK) {
+            state->all_ok = false;
+            return false;
+        }
+        ConstraintBlob eq(lib_getConstraint(CT_EQ));
+        eq.vars.push_back({v_res.var});
+        eq.vars.push_back({x_res.var});
+        MinionResult con_res = minion_addConstraintMidsearch(ctx, *state->instance, eq);
+        if(con_res != MINION_OK) {
+            state->all_ok = false;
+            return false;
+        }
+        state->constrained_count++;
+        return state->callback_count < 3;
+    }
+
+    // MID_DUPLICATE_NAME_ACROSS_CALLBACKS
+    const char* dup_name = "mid_dup";
+    if(state->callback_count == 1) {
+        MinionResult add_res =
+            minion_newVarMidsearch(ctx, *state->instance, (char*)dup_name, VAR_BOUND, 0, 1);
+        if(add_res != MINION_OK) {
+            state->all_ok = false;
+            return false;
+        }
+        state->added_count++;
+        return true;
+    }
+
+    state->duplicate_second_add =
+        minion_newVarMidsearch(ctx, *state->instance, (char*)dup_name, VAR_BOUND, 0, 1);
+    return false;
+}
+
+std::pair<bool, std::string> solve_midsearch_mutation(MinionContext* ctx, MidsearchScenario scenario) {
+    CSPInstance instance;
+    newVar(instance, "x", VAR_DISCRETE, {0, 2});
+    newVar(instance, "y", VAR_DISCRETE, {0, 2});
+    Var x = instance.vars.getSymbol("x");
+    Var y = instance.vars.getSymbol("y");
+
+    instance.print_matrix.push_back({x});
+    instance.print_matrix.push_back({y});
+    instance.searchOrder.push_back(SearchOrder({x, y}, ORDER_STATIC, false));
+
+    SearchOptions options;
+    options.findAllSolutions();
+    SearchMethod method;
+    method.preprocess = PropLevel_GAC;
+    method.propMethod = PropLevel_GAC;
+
+    MidsearchState state;
+    state.scenario = scenario;
+    state.instance = &instance;
+
+    MinionResult rc = runMinion(ctx, options, method, instance, midsearch_callback, &state);
+    if(rc != MINION_OK) {
+        return {false, "runMinion returned " + std::to_string((int)rc)};
+    }
+    if(!state.all_ok) {
+        return {false, "callback operation failed"};
+    }
+
+    if(scenario == MID_BULK_ADD_AND_CONSTRAIN) {
+        bool ok = (state.callback_count >= 1 && state.added_count == 40 && state.constrained_count == 40);
+        return {ok, "callbacks=" + std::to_string(state.callback_count) + ", added=" +
+                        std::to_string(state.added_count) + ", constrained=" +
+                        std::to_string(state.constrained_count)};
+    }
+
+    if(scenario == MID_MULTI_CALLBACK_ADD_AND_CONSTRAIN) {
+        bool ok = (state.callback_count >= 2 && state.added_count >= 2 && state.constrained_count >= 2);
+        return {ok, "callbacks=" + std::to_string(state.callback_count) + ", added=" +
+                        std::to_string(state.added_count) + ", constrained=" +
+                        std::to_string(state.constrained_count)};
+    }
+
+    bool ok = (state.callback_count == 2 && state.duplicate_second_add == MINION_PARSE_ERROR);
+    return {ok, "callbacks=" + std::to_string(state.callback_count) + ", second_add_result=" +
+                    std::to_string((int)state.duplicate_second_add)};
+}
+
 // ---- Test runners ----
 
 struct TestResult {
@@ -173,12 +326,17 @@ void check(std::vector<TestResult>& results, const std::string& name, int got, i
     results.push_back({name, ok, detail});
 }
 
+void check_bool(std::vector<TestResult>& results, const std::string& name, bool ok,
+                const std::string& detail) {
+    results.push_back({name, ok, detail});
+}
+
 void worker_thread(int thread_id, int iterations, std::vector<TestResult>& results) {
     for(int iter = 0; iter < iterations; iter++) {
         // Each iteration creates a fresh context, solves a problem, destroys it.
         // Vary the problem type and parameters.
 
-        int problem = (thread_id * 7 + iter * 3) % 5;
+        int problem = (thread_id * 7 + iter * 3) % 8;
 
         MinionContext* ctx = minion_newContext();
 
@@ -219,6 +377,30 @@ void worker_thread(int thread_id, int iterations, std::vector<TestResult>& resul
             int got = solve_pairs(ctx, n);
             check(results, "T" + std::to_string(thread_id) + " iter" + std::to_string(iter)
                   + " pairs(n=" + std::to_string(n) + ")", got, expected_pairs(n));
+            break;
+        }
+        case 5: {
+            auto ret = solve_midsearch_mutation(ctx, MID_BULK_ADD_AND_CONSTRAIN);
+            check_bool(results,
+                       "T" + std::to_string(thread_id) + " iter" + std::to_string(iter)
+                       + " mid_bulk_add_and_constrain",
+                       ret.first, ret.second);
+            break;
+        }
+        case 6: {
+            auto ret = solve_midsearch_mutation(ctx, MID_MULTI_CALLBACK_ADD_AND_CONSTRAIN);
+            check_bool(results,
+                       "T" + std::to_string(thread_id) + " iter" + std::to_string(iter)
+                       + " mid_multi_callback_add_and_constrain",
+                       ret.first, ret.second);
+            break;
+        }
+        case 7: {
+            auto ret = solve_midsearch_mutation(ctx, MID_DUPLICATE_NAME_ACROSS_CALLBACKS);
+            check_bool(results,
+                       "T" + std::to_string(thread_id) + " iter" + std::to_string(iter)
+                       + " mid_duplicate_name_across_callbacks",
+                       ret.first, ret.second);
             break;
         }
         }

--- a/test_instances/test_multithread.cpp
+++ b/test_instances/test_multithread.cpp
@@ -48,8 +48,8 @@ int solve_pairs(MinionContext* ctx, int n) {
     method.preprocess = PropLevel_GAC;
     method.propMethod = PropLevel_GAC;
 
-    ReturnCodes rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
-    assert(rc == OK);
+    MinionResult rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
+    assert(rc == MINION_OK);
 
     // Read solution count from TableOut
     char* sols_str = TableOut_get(ctx, (char*)"SolutionsFound");
@@ -86,8 +86,8 @@ int solve_alldiff(MinionContext* ctx, int k, int n) {
     method.preprocess = PropLevel_GAC;
     method.propMethod = PropLevel_GAC;
 
-    ReturnCodes rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
-    assert(rc == OK);
+    MinionResult rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
+    assert(rc == MINION_OK);
 
     char* sols_str = TableOut_get(ctx, (char*)"SolutionsFound");
     assert(sols_str != nullptr);
@@ -125,8 +125,8 @@ int solve_bounded_sum(MinionContext* ctx, int k, int n, int bound) {
     method.preprocess = PropLevel_GAC;
     method.propMethod = PropLevel_GAC;
 
-    ReturnCodes rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
-    assert(rc == OK);
+    MinionResult rc = runMinion(ctx, options, method, instance, +[](MinionContext*, void*) -> bool { return true; }, nullptr);
+    assert(rc == MINION_OK);
 
     char* sols_str = TableOut_get(ctx, (char*)"SolutionsFound");
     assert(sols_str != nullptr);


### PR DESCRIPTION
Adds new library-level stress coverage for mid-search model mutation in test_instances/test_multithread.cpp

### What this PR adds

This extends the existing multithreaded library test binary with focused scenarios for the new mid-search APIs (minion_newVarMidsearch + minion_addConstraintMidsearch):

- Adds many variables mid-search in one callback and immediately adds constraints over them
- Repeats add/constrain across multiple solution callbacks to exercise callback/backtracking progression
- Attempts to add the same variable name twice and checks for a clean parse error (no crash/UB)

### Why

We recently hit segfaults when new variables were introduced during search and then referenced by mid-search constraints. These tests are meant to “kick the tyres” on that path and guard against regressions in the library interface

### Validation

Built and ran Minion in --lib mode (make test in a lib build dir); the updated multithread stress suite passes