### PR TITLE
disable wall-clock timeouts after libwrapper runs

### DIFF
--- a/minion-sys/src/error.rs
+++ b/minion-sys/src/error.rs
@@ -27,7 +27,7 @@ pub enum MinionError {
 ///
 /// Invalid usage of this library should throw an error before Minion is even run. Therefore, these
 /// should be quite rare. Consider creating an issue on
-/// [Github](https://github.com/conjure-cp/conjure-oxide) if these occur regularly!
+/// [GitHub](https://github.com/conjure-cp/conjure-oxide) if these occur regularly!
 #[derive(Debug, Error, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RuntimeError {

--- a/minion/libwrapper.cpp
+++ b/minion/libwrapper.cpp
@@ -341,6 +341,7 @@ static MinionResult runMinionImpl(MinionContext* ctx, SearchOptions& options,
 
   if(installAlarms) {
     Parallel::endParallelMinion();
+    Parallel::setupAlarm(false, 0, false);
   }
 
   // Don't reset context here - caller may still query results via

--- a/minion/system/trigger_timer.cpp
+++ b/minion/system/trigger_timer.cpp
@@ -29,6 +29,8 @@ void CALLBACK ReallyStop(void*, BOOLEAN) {
   exit(1);
 }
 
+static HANDLE mTimerHandle = NULL;
+
 void activateTrigger(std::atomic<bool>* b, bool timeoutActive, int timeout, bool CPUTime) {
   if(CPUTime)
     cerr << "CPU-time timing not available on windows, falling back on clock" << endl;
@@ -36,13 +38,18 @@ void activateTrigger(std::atomic<bool>* b, bool timeoutActive, int timeout, bool
   trig = b;
   *trig = false;
 
-  HANDLE mTimerHandle;
+  if(mTimerHandle != NULL) {
+    ::DeleteTimerQueueTimer(NULL, mTimerHandle, INVALID_HANDLE_VALUE);
+    mTimerHandle = NULL;
+  }
 
   if(timeoutActive) {
-    if(timeout <= 0)
+    if(timeout <= 0) {
       *trig = true;
-    BOOL success = ::CreateTimerQueueTimer(&mTimerHandle, NULL, TimerProc, NULL, timeout * 1000, 0,
-                                           WT_EXECUTEINTIMERTHREAD);
+    } else {
+      ::CreateTimerQueueTimer(&mTimerHandle, NULL, TimerProc, NULL, timeout * 1000, 0,
+                              WT_EXECUTEINTIMERTHREAD);
+    }
   }
 }
 
@@ -71,6 +78,7 @@ void activateTrigger(std::atomic<bool>* b, bool timeoutActive, int timeout,
 
   signal(SIGXCPU, triggerFunction);
   signal(SIGALRM, triggerFunction);
+  alarm(0);
   if(timeoutActive) {
     if(timeout <= 0)
       *trig = true;


### PR DESCRIPTION
If a run finishes before the time limit, the alarm seems to remain active.

This change cancels existing timers when a standalone runMinion call finishes.